### PR TITLE
genfstab requires awk

### DIFF
--- a/vps2arch
+++ b/vps2arch
@@ -85,7 +85,7 @@ configure_chroot() {
 	if ! is_openvz && ! pidof haveged >/dev/null; then
 		# Disable signature check, install and launch haveged and re-enable signature checks.
 		sed -i.bak "s/^[[:space:]]*SigLevel[[:space:]]*=.*$/SigLevel = Never/" "/root.$cpu_type/etc/pacman.conf"
-		chroot_exec 'pacman --noconfirm -Sy haveged && haveged'
+		chroot_exec 'pacman --noconfirm -Sy haveged awk && haveged'
 		mv "/root.$cpu_type/etc/pacman.conf.bak" "/root.$cpu_type/etc/pacman.conf"
 	fi
 	chroot_exec 'pacman-key --init && pacman-key --populate archlinux'


### PR DESCRIPTION
On the latest bootstrap, (2018.07.01), I'm getting errors during the fstab creation that awk is missing. This is meant to remedy it.